### PR TITLE
Update Audit Logging configuration and event building

### DIFF
--- a/src/main/java/ca/uhn/fhir/jpa/starter/koppeltaal/config/FhirServerAuditLogConfiguration.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/koppeltaal/config/FhirServerAuditLogConfiguration.java
@@ -10,6 +10,7 @@ import org.springframework.context.annotation.Configuration;
 @ConfigurationProperties(prefix = "fhir.server.auditlog")
 public class FhirServerAuditLogConfiguration {
 	private boolean enabled;
+  @Deprecated
 	private String site;
 	private Observer observer = new Observer();
 
@@ -21,7 +22,8 @@ public class FhirServerAuditLogConfiguration {
 		this.observer = observer;
 	}
 
-	public String getSite() {
+	@Deprecated
+  public String getSite() {
 		return site;
 	}
 

--- a/src/main/java/ca/uhn/fhir/jpa/starter/koppeltaal/dto/AuditEventDto.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/koppeltaal/dto/AuditEventDto.java
@@ -47,8 +47,9 @@ public class AuditEventDto {
   List<AgentAndTypeDto> agents = new ArrayList<>();
 	String query;
 	List<Reference> resources = new ArrayList<>();
+  private String site;
 
-	public void addResource(Reference r) {
+  public void addResource(Reference r) {
 		this.resources.add(r);
 	}
 
@@ -145,6 +146,14 @@ public class AuditEventDto {
       ", query='" + query + '\'' +
       ", resources=" + resources +
       '}';
+  }
+
+  public void setSite(String site) {
+    this.site = site;
+  }
+
+  public String getSite() {
+    return site;
   }
 
   public enum EventType {

--- a/src/main/java/ca/uhn/fhir/jpa/starter/koppeltaal/service/AuditEventBuilder.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/koppeltaal/service/AuditEventBuilder.java
@@ -82,7 +82,7 @@ public class AuditEventBuilder {
       }
       auditEvent.addEntity(entity);
     }
-    auditEvent.setSource(buildEventSource());
+    auditEvent.setSource(buildEventSource(dto.getSite()));
     auditEvent.setRecorded(dto.getDateTime());
 
     getResourceOriginExtension(dto)
@@ -184,9 +184,9 @@ public class AuditEventBuilder {
     return type;
   }
 
-  private AuditEvent.AuditEventSourceComponent buildEventSource() {
+  private AuditEvent.AuditEventSourceComponent buildEventSource(String site) {
 		return new AuditEvent.AuditEventSourceComponent()
-			.setSite(fhirServerAuditLogConfiguration.getSite())
+			.setSite(site)
 			.setObserver(newReference(self));
 	}
 


### PR DESCRIPTION
The 'site' variable in the FhirServerAuditLogConfiguration has been deprecated. Instead, the 'site' value is now directly retrieved from servlet requests in the AbstractAuditEventInterceptor class. Consequently, the AuditEventBuilder now makes use of the incoming site value when building event sources. A 'site' field has also been added to the AuditEventDto class to accommodate these changes.