### PR TITLE
Simplify ResourceOriginAuthorizationInterceptor by consolidating deleted logic

### DIFF
--- a/.github/workflows/gitlab-mirror.yaml
+++ b/.github/workflows/gitlab-mirror.yaml
@@ -40,9 +40,11 @@ jobs:
             git remote add gitlab "$GITLAB_REMOTE"
           fi
 
-          # 2. fetch all remote branches to ensure we have everything
-          git fetch origin '+refs/heads/*:refs/heads/*'
+          # 2. fetch all remote branches as remote tracking branches
+          git fetch origin '+refs/heads/*:refs/remotes/origin/*'
 
-          # 3. mirror branches, then tags; overwrite anything that differs
-          git push --prune --force --all  gitlab
-          git push --prune --force --tags gitlab
+          # 3. push all branches from origin to gitlab (without --prune to avoid deletion issues)
+          git push gitlab 'refs/remotes/origin/*:refs/heads/*' --force
+
+          # 4. push all tags
+          git push gitlab --tags --force

--- a/.github/workflows/gitlab-mirror.yaml
+++ b/.github/workflows/gitlab-mirror.yaml
@@ -41,10 +41,8 @@ jobs:
           fi
 
           # 2. fetch all remote branches as remote tracking branches
-          git fetch origin '+refs/heads/*:refs/remotes/origin/*'
+          git fetch origin --all  --prune --prune-tags
 
-          # 3. push all branches from origin to gitlab (without --prune to avoid deletion issues)
-          git push gitlab 'refs/remotes/origin/*:refs/heads/*' --force
-
-          # 4. push all tags
-          git push gitlab --tags --force
+          # 3. mirror branches, then tags; overwrite anything that differs
+          git push --prune --force --all  gitlab
+          git push --prune --force --tags gitlab

--- a/.github/workflows/gitlab-mirror.yaml
+++ b/.github/workflows/gitlab-mirror.yaml
@@ -41,7 +41,7 @@ jobs:
           fi
 
           # 2. fetch all remote branches as remote tracking branches
-          git fetch origin --all  --prune --prune-tags
+          git fetch origin --tags  --prune --prune-tags
 
           # 3. mirror branches, then tags; overwrite anything that differs
           git push --prune --force --all  gitlab

--- a/.github/workflows/gitlab-mirror.yaml
+++ b/.github/workflows/gitlab-mirror.yaml
@@ -40,9 +40,6 @@ jobs:
             git remote add gitlab "$GITLAB_REMOTE"
           fi
 
-          # 2. fetch all remote branches as remote tracking branches
-          git fetch origin --tags  --prune --prune-tags
-
-          # 3. mirror branches, then tags; overwrite anything that differs
+          # mirror branches, then tags; overwrite anything that differs
           git push --prune --force --all  gitlab
           git push --prune --force --tags gitlab

--- a/.github/workflows/gitlab-mirror.yaml
+++ b/.github/workflows/gitlab-mirror.yaml
@@ -40,6 +40,9 @@ jobs:
             git remote add gitlab "$GITLAB_REMOTE"
           fi
 
-          # mirror branches, then tags; overwrite anything that differs
+          # 2. fetch all remote branches to ensure we have everything
+          git fetch origin '+refs/heads/*:refs/heads/*'
+
+          # 3. mirror branches, then tags; overwrite anything that differs
           git push --prune --force --all  gitlab
           git push --prune --force --tags gitlab

--- a/src/main/java/ca/uhn/fhir/jpa/starter/koppeltaal/interceptor/ResourceOriginAuthorizationInterceptor.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/koppeltaal/interceptor/ResourceOriginAuthorizationInterceptor.java
@@ -149,25 +149,15 @@ public class ResourceOriginAuthorizationInterceptor extends BaseAuthorizationInt
       try {
         final IFhirResourceDao<?> resourceDao = daoRegistry.getResourceDao(requestDetails.getResourceName());
 
-        // First try to read without allowDeleted flag
-        IBaseResource existingResource;
-        try {
-          existingResource = resourceDao.read(resourceId, requestDetails);
-        } catch (ResourceGoneException e) {
-          // Resource is deleted - check if this is a history request
-          if (isFullHistoryCheck(requestDetails)) {
-            LOG.debug("Resource {}/{} is deleted, but this is a history request - reading with allowDeleted=true",
-                     requestDetails.getResourceName(), resourceId.getIdPart());
-            // For history requests, we need to read the deleted resource to check its resource-origin
-            existingResource = resourceDao.read(resourceId, requestDetails, true);
-          } else {
-            // For non-history requests, deleted resources should return 410 Gone
-            LOG.debug("Resource {}/{} is deleted and this is not a history request - returning 410 Gone",
-                     requestDetails.getResourceName(), resourceId.getIdPart());
-            throw e;
-          }
+        // Determine if we should allow reading deleted resources based on whether this is a history request
+        boolean allowDeleted = isFullHistoryCheck(requestDetails);
+
+        if (allowDeleted) {
+          LOG.debug("History request for {}/{} - reading with allowDeleted=true",
+                   requestDetails.getResourceName(), resourceId.getIdPart());
         }
 
+        IBaseResource existingResource = resourceDao.read(resourceId, requestDetails, allowDeleted);
         return getResourceOriginDeviceReference(existingResource, requestDetails);
       } catch (ResourceGoneException e) {
         LOG.warn("Failed to read resource {}/{} for authorization check",

--- a/src/test/java/ca/uhn/fhir/jpa/starter/koppeltaal/interceptor/BaseResourceOriginTest.java
+++ b/src/test/java/ca/uhn/fhir/jpa/starter/koppeltaal/interceptor/BaseResourceOriginTest.java
@@ -74,7 +74,7 @@ public class BaseResourceOriginTest {
         requestDetails.setResource(instance);
 
         if(requestType != RequestTypeEnum.POST) {
-          when(resourceDaoMock.read(any(IIdType.class), any(RequestDetails.class)))
+          when(resourceDaoMock.read(any(IIdType.class), any(RequestDetails.class), anyBoolean()))
             .thenReturn(instance);
         }
       } catch (Exception e) {

--- a/src/test/java/ca/uhn/fhir/jpa/starter/koppeltaal/interceptor/ResourceOriginAuthorizationInterceptorTest.java
+++ b/src/test/java/ca/uhn/fhir/jpa/starter/koppeltaal/interceptor/ResourceOriginAuthorizationInterceptorTest.java
@@ -356,7 +356,7 @@ class ResourceOriginAuthorizationInterceptorTest extends BaseResourceOriginTest 
     IFhirResourceDao<ActivityDefinition> activityDefinitionDao = (IFhirResourceDao<ActivityDefinition>) mock(IFhirResourceDao.class);
     when(daoRegistry.getResourceDao(ResourceType.ActivityDefinition.name())).thenReturn(activityDefinitionDao);
 
-    when(activityDefinitionDao.read(eq(resourceId), eq(requestDetails), eq(true))).thenReturn(deletedResource);
+    when(activityDefinitionDao.read(eq(resourceId), eq(requestDetails), eq(false))).thenReturn(deletedResource);
 
     // Mock resource origin utility - no origin for deleted resource
     resourceOriginUtil.when(() -> ResourceOriginUtil.getResourceOriginDeviceId(eq(deletedResource)))
@@ -390,8 +390,8 @@ class ResourceOriginAuthorizationInterceptorTest extends BaseResourceOriginTest 
     IFhirResourceDao<ActivityDefinition> activityDefinitionDao = (IFhirResourceDao<ActivityDefinition>) mock(IFhirResourceDao.class);
     when(daoRegistry.getResourceDao(ResourceType.ActivityDefinition.name())).thenReturn(activityDefinitionDao);
 
-    // Mock the DAO to throw ResourceGoneException when trying to read the deleted resource
-    when(activityDefinitionDao.read(eq(resourceId), eq(requestDetails)))
+    // Mock the DAO to throw ResourceGoneException when trying to read the deleted resource (allowDeleted=false)
+    when(activityDefinitionDao.read(eq(resourceId), eq(requestDetails), eq(false)))
         .thenThrow(new ResourceGoneException("Resource has been deleted"));
 
     // This should throw ResourceGoneException (which translates to HTTP 410 Gone)


### PR DESCRIPTION
Moved from catching an exception to using the overloaded method with logic around te delete flag.